### PR TITLE
Add real usage numbers, real-world example, bump license-hook to v1.0.0 (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Your AI writes code. But does it know how to release it? Check license complianc
 
 **Dev Tools** is a collection of battle-tested tools for AI-assisted software development. Built by a team of humans and AIs shipping real software together.
 
+Used internally to manage 100+ repos, 200+ releases, and daily license compliance across the [wipcomputer](https://github.com/wipcomputer) org. These tools run in production every day.
+
+**Real-world example:** [wip-universal-installer](https://github.com/wipcomputer/wip-universal-installer) ships its releases entirely through wip-release. 6 releases, v2.1.5, changelog and GitHub releases all generated automatically. Browse its [release history](https://github.com/wipcomputer/wip-universal-installer/releases) to see the output.
+
 ## Tools
 
 ### wip-release

--- a/tools/wip-license-hook/package.json
+++ b/tools/wip-license-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-hook",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "License rug-pull detection and dependency license compliance for open source projects",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
Synced from private repo (commit 17c0b2c).