### PR TITLE
v1.9.12: Add skill publish to website: after every release, SKILL.md is auto-copied to yoursite.com/install/{name}.txt and deployed. Configured per repo with .publish-skill.json. Non-blocking.

### DIFF
--- a/.publish-skill.json
+++ b/.publish-skill.json
@@ -1,0 +1,3 @@
+{
+  "name": "devops-toolbox"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
 
 
 
+
+## 1.9.12 (2026-03-13)
+
+Add skill publish to website: after every release, SKILL.md is auto-copied to yoursite.com/install/{name}.txt and deployed. Configured per repo with .publish-skill.json. Non-blocking.
+
 ## 1.9.11 (2026-03-13)
 
 wip-install bootstraps LDM OS silently when not on PATH

--- a/DEV-GUIDE-GENERAL-PUBLIC.md
+++ b/DEV-GUIDE-GENERAL-PUBLIC.md
@@ -168,6 +168,18 @@ The release flow must happen in this exact order:
 
 If you skip step 2 or do it manually (e.g. `git tag` + `git push` without creating a GitHub release), `deploy-public` will create the public release with empty notes. The script pulls notes from the private repo's GitHub release. No release on private = no notes on public.
 
+### Merge, Deploy, Install ... Three Separate Steps
+
+These are three distinct actions. Never combine them.
+
+| Step | What it means | What happens |
+|------|--------------|-------------|
+| **Merge** | Development done | PR merged to private repo's main. Code lands. Nothing else changes. |
+| **Deploy** | Ship to public | `wip-release` + `deploy-public.sh`. Package published. Available to the world. **Not on your machine yet.** |
+| **Install** | Put it on your system | Run the install prompt (`crystal init`, `ldm install`, etc.). Only when the user says "install." |
+
+After Deploy, stop. Do not copy files to extension directories. Do not run `npm install -g`. Do not run `npm link`. The user tests the install flow by running the install prompt. That's how you dogfood.
+
 **If you must release manually** (no root package.json, toolbox repos, etc.):
 1. Update CHANGELOG.md and SKILL.md version
 2. Commit, PR, merge

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ As Andrej Karpathy [said](https://x.com/karpathy/status/2024583544157458452): *"
 - *Stable*
 - [Read more about Post-Merge Naming](tools/post-merge-rename/SKILL.md)
 
+**Skill Publish to Website**
+- After every release, your SKILL.md goes live as plain text on your website. No manual copying. No forgetting.
+- Copies SKILL.md to `yoursite.com/install/{name}.txt` and deploys automatically. Any AI can fetch the URL and get clean, parseable instructions. Like `robots.txt` but for agent install prompts.
+- **Interfaces:** Module (built into Release Pipeline)
+- *Stable*
+
 ### License, Compliance, and Protection
 
 **Identity File Protection**
@@ -151,15 +157,16 @@ As Andrej Karpathy [said](https://x.com/karpathy/status/2024583544157458452): *"
 | 4 | Release Pipeline | Y | Y | Y | | Y | |
 | 5 | Private-to-Public Sync | Y | | | | Y | |
 | 6 | Post-Merge Branch Naming | Y | | | | Y | |
+| 7 | Skill Publish to Website | | Y | | | | |
 | | **License, Compliance, and Protection** | | | | | | |
-| 7 | Identity File Protection | Y | Y | | Y | Y | Y |
-| 8 | License Guard | Y | | | | | |
-| 9 | License Rug-Pull Detection | Y | Y | Y | | Y | |
+| 8 | Identity File Protection | Y | Y | | Y | Y | Y |
+| 9 | License Guard | Y | | | | | |
+| 10 | License Rug-Pull Detection | Y | Y | Y | | Y | |
 | | **Repo Management** | | | | | | |
-| 10 | Repo Visibility Guard | Y | Y | Y | Y | Y | Y |
-| 11 | Repo Manifest Reconciler | Y | Y | Y | | Y | |
-| 12 | Repo Init | Y | | | | Y | |
-| 13 | README Formatter | Y | | | | Y | |
+| 11 | Repo Visibility Guard | Y | Y | Y | Y | Y | Y |
+| 12 | Repo Manifest Reconciler | Y | Y | Y | | Y | |
+| 13 | Repo Init | Y | | | | Y | |
+| 14 | README Formatter | Y | | | | Y | |
 
 ## More Info
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, module, mcp, skill, hook, plugin]
 metadata:
   display-name: "WIP AI DevOps Toolbox"
-  version: "1.9.11"
+  version: "1.9.12"
   homepage: "https://github.com/wipcomputer/wip-ai-devops-toolbox"
   author: "Parker Todd Brooks"
   category: dev-tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ai-devops-toolbox",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "The complete AI DevOps toolkit for AI-assisted development teams.",
   "private": true,

--- a/tools/ai-dir-template/package.json
+++ b/tools/ai-dir-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-init",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Scaffold the standard ai/ directory structure in any repo",
   "type": "module",
   "bin": {

--- a/tools/deploy-public/package.json
+++ b/tools/deploy-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/deploy-public",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Private-to-public repo sync. Excludes ai/ folder, creates PR, merges, cleans up branches.",
   "bin": {
     "deploy-public": "./deploy-public.sh"

--- a/tools/post-merge-rename/package.json
+++ b/tools/post-merge-rename/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/post-merge-rename",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Post-merge branch renaming. Appends --merged-YYYY-MM-DD to preserve history.",
   "bin": {
     "post-merge-rename": "./post-merge-rename.sh"

--- a/tools/wip-file-guard/package.json
+++ b/tools/wip-file-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-file-guard",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "Hook that blocks destructive edits to protected identity files. For Claude Code CLI and OpenClaw.",
   "main": "guard.mjs",

--- a/tools/wip-license-guard/package.json
+++ b/tools/wip-license-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-guard",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "License compliance for your own repos. Ensures correct copyright, dual-license blocks, and LICENSE files.",
   "type": "module",
   "bin": {

--- a/tools/wip-license-hook/package.json
+++ b/tools/wip-license-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-hook",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "License rug-pull detection and dependency license compliance for open source projects",
   "type": "module",
   "main": "dist/cli/index.js",

--- a/tools/wip-readme-format/package.json
+++ b/tools/wip-readme-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-readme-format",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Reformat any repo's README to follow the WIP Computer standard. Agent-first, human-readable.",
   "type": "module",
   "bin": {

--- a/tools/wip-release/cli.js
+++ b/tools/wip-release/cli.js
@@ -125,6 +125,12 @@ Release notes (highest priority wins, files ALWAYS beat --notes flag):
   4. --notes="text"             Fallback only (use for repos without release notes files)
   Written notes on disk always take priority over a CLI one-liner.
 
+Skill publish to website:
+  Add .publish-skill.json to repo root: { "name": "my-tool" }
+  Set WIP_WEBSITE_REPO env var to your website repo path.
+  After release, SKILL.md is copied to {website}/wip.computer/install/{name}.txt
+  and deploy.sh is run to push to VPS.
+
 Pipeline:
   1. Bump package.json version
   2. Sync SKILL.md version (if exists)
@@ -133,7 +139,8 @@ Pipeline:
   5. Push to remote
   6. npm publish (via 1Password)
   7. GitHub Packages publish
-  8. GitHub release create`);
+  8. GitHub release create
+  9. Publish SKILL.md to website (if configured)`);
   process.exit(level ? 0 : 1);
 }
 

--- a/tools/wip-release/core.mjs
+++ b/tools/wip-release/core.mjs
@@ -458,6 +458,78 @@ export function publishClawHub(repoPath, newVersion, notes) {
   return true;
 }
 
+// ── Skill Publish ────────────────────────────────────────────────────
+
+/**
+ * Publish SKILL.md to website as plain text.
+ *
+ * Reads .publish-skill.json from repo root:
+ *   { "name": "memory-crystal" }
+ *
+ * Uses WIP_WEBSITE_REPO env var for website repo path.
+ * Copies SKILL.md to {website}/wip.computer/install/{name}.txt
+ * Then runs deploy.sh to push to VPS.
+ *
+ * Non-blocking: returns result, never throws.
+ */
+export function publishSkillToWebsite(repoPath) {
+  const configPath = join(repoPath, '.publish-skill.json');
+  if (!existsSync(configPath)) return { skipped: true, reason: 'no .publish-skill.json' };
+
+  const websiteRepo = process.env.WIP_WEBSITE_REPO;
+  if (!websiteRepo) return { skipped: true, reason: 'WIP_WEBSITE_REPO not set' };
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch (e) {
+    return { ok: false, error: `bad .publish-skill.json: ${e.message}` };
+  }
+
+  if (!config.name) return { ok: false, error: '.publish-skill.json missing "name"' };
+
+  // Find SKILL.md: check root, then skills/*/SKILL.md
+  let skillFile = join(repoPath, 'SKILL.md');
+  if (!existsSync(skillFile)) {
+    const skillsDir = join(repoPath, 'skills');
+    if (existsSync(skillsDir)) {
+      for (const sub of readdirSync(skillsDir)) {
+        const candidate = join(skillsDir, sub, 'SKILL.md');
+        if (existsSync(candidate)) { skillFile = candidate; break; }
+      }
+    }
+  }
+  if (!existsSync(skillFile)) return { ok: false, error: 'no SKILL.md found' };
+
+  // Copy to website install dir
+  const installDir = join(websiteRepo, 'wip.computer', 'install');
+  if (!existsSync(installDir)) {
+    try { mkdirSync(installDir, { recursive: true }); } catch {}
+  }
+
+  const targetFile = join(installDir, `${config.name}.txt`);
+  try {
+    const content = readFileSync(skillFile, 'utf8');
+    writeFileSync(targetFile, content);
+  } catch (e) {
+    return { ok: false, error: `copy failed: ${e.message}` };
+  }
+
+  // Deploy to VPS (non-blocking ... warn on failure)
+  const deployScript = join(websiteRepo, 'deploy.sh');
+  if (existsSync(deployScript)) {
+    try {
+      execSync(`bash deploy.sh`, { cwd: websiteRepo, stdio: 'pipe', timeout: 30000 });
+    } catch (e) {
+      return { ok: true, deployed: false, target: config.name, error: `deploy failed: ${e.message}` };
+    }
+  } else {
+    return { ok: true, deployed: false, target: config.name, error: 'no deploy.sh found' };
+  }
+
+  return { ok: true, deployed: true, target: config.name };
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function getNpmToken() {
@@ -745,6 +817,19 @@ export async function release({ repoPath, level, notes, notesSource, dryRun, noP
       console.log(`  [dry run] Would publish to GitHub Packages`);
       console.log(`  [dry run] Would create GitHub release v${newVersion}`);
       if (hasSkill) console.log(`  [dry run] Would publish to ClawHub`);
+      // Skill-to-website dry run
+      const publishConfig = join(repoPath, '.publish-skill.json');
+      if (existsSync(publishConfig)) {
+        try {
+          const pc = JSON.parse(readFileSync(publishConfig, 'utf8'));
+          const envSet = !!process.env.WIP_WEBSITE_REPO;
+          if (pc.name && envSet) {
+            console.log(`  [dry run] Would publish SKILL.md to website: install/${pc.name}.txt`);
+          } else if (pc.name && !envSet) {
+            console.log(`  [dry run] Would publish to website but WIP_WEBSITE_REPO not set`);
+          }
+        } catch {}
+      }
     }
     console.log('');
     console.log(`  Dry run complete. No changes made.`);
@@ -877,6 +962,22 @@ export async function release({ repoPath, level, notes, notesSource, dryRun, noP
           }
         }
       }
+    }
+
+    // 9.5. Publish SKILL.md to website as plain text
+    const skillWebResult = publishSkillToWebsite(repoPath);
+    if (skillWebResult.skipped) {
+      // Silent skip ... no config or env var
+    } else if (skillWebResult.ok) {
+      const deployNote = skillWebResult.deployed ? '' : ' (copied, deploy skipped)';
+      distResults.push({ target: 'Website', status: 'ok', detail: `install/${skillWebResult.target}.txt${deployNote}` });
+      console.log(`  ✓ Published to website: install/${skillWebResult.target}.txt${deployNote}`);
+      if (!skillWebResult.deployed && skillWebResult.error) {
+        console.log(`    ! ${skillWebResult.error}`);
+      }
+    } else {
+      distResults.push({ target: 'Website', status: 'failed', detail: skillWebResult.error });
+      console.log(`  ✗ Website publish failed: ${skillWebResult.error}`);
     }
   }
 

--- a/tools/wip-release/package.json
+++ b/tools/wip-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-release",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "One-command release pipeline. Bumps version, updates changelog + SKILL.md, publishes to npm + GitHub.",
   "main": "core.mjs",

--- a/tools/wip-repo-permissions-hook/package.json
+++ b/tools/wip-repo-permissions-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-permissions-hook",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "Repo visibility guard. Blocks repos from going public without a -private counterpart.",
   "main": "core.mjs",

--- a/tools/wip-repos/package.json
+++ b/tools/wip-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repos",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "Repo manifest reconciler. Single source of truth for repo organization. Like prettier for folder structure.",
   "main": "core.mjs",

--- a/tools/wip-universal-installer/package.json
+++ b/tools/wip-universal-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/universal-installer",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "type": "module",
   "description": "The Universal Interface specification for agent-native software. Teaches your AI how to build repos with every interface: CLI, Module, MCP Server, OpenClaw Plugin, Skill, Claude Code Hook.",
   "main": "detect.mjs",


### PR DESCRIPTION
Synced from private repo (commit 881c9e7).