### PR TITLE
v1.9.14: Add readme-license command to wip-license-guard. Scans all repos, applies standard license block, removes from sub-tools. License Guard now Stable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
 
 
 
+
+## 1.9.14 (2026-03-14)
+
+Add readme-license command to wip-license-guard. Scans all repos, applies standard license block, removes from sub-tools. License Guard now Stable.
+
 ## 1.9.13 (2026-03-14)
 
 Release.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ As Andrej Karpathy [said](https://x.com/karpathy/status/2024583544157458452): *"
 - Enforce licensing on every commit. Copyright, dual-license, CLA. Checked automatically.
 - Ensures your own repos have correct copyright, license type, and LICENSE files. Interactive first-run setup. Toolbox-aware: checks every sub-tool. Auto-fix mode repairs issues
 - **Interfaces:** CLI
-- *Beta*
+- *Stable*
 - [Read more about License Guard](tools/wip-license-guard/cli.mjs)
 
 **License Rug-Pull Detection**

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, module, mcp, skill, hook, plugin]
 metadata:
   display-name: "WIP AI DevOps Toolbox"
-  version: "1.9.13"
+  version: "1.9.14"
   homepage: "https://github.com/wipcomputer/wip-ai-devops-toolbox"
   author: "Parker Todd Brooks"
   category: dev-tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ai-devops-toolbox",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "The complete AI DevOps toolkit for AI-assisted development teams.",
   "private": true,

--- a/tools/ai-dir-template/package.json
+++ b/tools/ai-dir-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-init",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Scaffold the standard ai/ directory structure in any repo",
   "type": "module",
   "bin": {

--- a/tools/deploy-public/package.json
+++ b/tools/deploy-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/deploy-public",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Private-to-public repo sync. Excludes ai/ folder, creates PR, merges, cleans up branches.",
   "bin": {
     "deploy-public": "./deploy-public.sh"

--- a/tools/post-merge-rename/package.json
+++ b/tools/post-merge-rename/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/post-merge-rename",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Post-merge branch renaming. Appends --merged-YYYY-MM-DD to preserve history.",
   "bin": {
     "post-merge-rename": "./post-merge-rename.sh"

--- a/tools/wip-file-guard/package.json
+++ b/tools/wip-file-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-file-guard",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "Hook that blocks destructive edits to protected identity files. For Claude Code CLI and OpenClaw.",
   "main": "guard.mjs",

--- a/tools/wip-license-guard/cli.mjs
+++ b/tools/wip-license-guard/cli.mjs
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
-import { generateLicense, generateReadmeBlock } from './core.mjs';
+import { generateLicense, generateReadmeBlock, replaceReadmeLicenseSection, removeReadmeLicenseSection } from './core.mjs';
 
 const args = process.argv.slice(2);
 const HELP_FLAGS = ['--help', '-h', 'help'];
@@ -320,12 +320,128 @@ async function check(repoPath) {
   return issues;
 }
 
+async function readmeLicense(targetPath) {
+  log(`\n  wip-license-guard readme-license${FIX ? ' --fix' : ''}\n`);
+
+  // Detect if targetPath is a single repo or a directory of repos
+  const repos = [];
+  const configPath = join(targetPath, '.license-guard.json');
+  if (existsSync(configPath)) {
+    // Single repo
+    repos.push(targetPath);
+  } else {
+    // Directory of repos (or nested categories like ldm-os/components/)
+    const scanDir = (dir) => {
+      try {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === '_trash') continue;
+          const sub = join(dir, entry.name);
+          if (existsSync(join(sub, '.license-guard.json'))) {
+            repos.push(sub);
+          } else if (existsSync(join(sub, 'package.json')) || existsSync(join(sub, 'README.md'))) {
+            repos.push(sub);
+          } else {
+            scanDir(sub); // recurse into category folders
+          }
+        }
+      } catch {}
+    };
+    scanDir(targetPath);
+  }
+
+  if (repos.length === 0) {
+    warn('No repos found. Point at a repo or a directory containing repos.');
+    return 1;
+  }
+
+  log(`  Found ${repos.length} repo(s)\n`);
+
+  let totalIssues = 0;
+
+  for (const repoPath of repos) {
+    const repoName = repoPath.split('/').pop();
+    const repoConfig = join(repoPath, '.license-guard.json');
+    const config = existsSync(repoConfig)
+      ? JSON.parse(readFileSync(repoConfig, 'utf8'))
+      : WIP_STANDARD;
+
+    // 1. Check main README
+    const readmePath = join(repoPath, 'README.md');
+    if (existsSync(readmePath)) {
+      const content = readFileSync(readmePath, 'utf8');
+      const expected = generateReadmeBlock(config);
+
+      if (content.includes('### Can I use this?') && content.includes('Dual-license model')) {
+        ok(`${repoName}/README.md ... standard license block`);
+      } else if (content.includes('## License')) {
+        warn(`${repoName}/README.md ... non-standard license section`);
+        totalIssues++;
+        if (FIX) {
+          const updated = replaceReadmeLicenseSection(content, config);
+          writeFileSync(readmePath, updated);
+          ok(`${repoName}/README.md ... updated to standard (--fix)`);
+          totalIssues--;
+        }
+      } else {
+        warn(`${repoName}/README.md ... missing ## License`);
+        totalIssues++;
+        if (FIX) {
+          const updated = replaceReadmeLicenseSection(content, config);
+          writeFileSync(readmePath, updated);
+          ok(`${repoName}/README.md ... added standard block (--fix)`);
+          totalIssues--;
+        }
+      }
+    } else {
+      warn(`${repoName}/README.md ... not found`);
+      totalIssues++;
+    }
+
+    // 2. Check sub-tool READMEs (should NOT have license sections)
+    const toolsDir = join(repoPath, 'tools');
+    if (existsSync(toolsDir)) {
+      try {
+        for (const tool of readdirSync(toolsDir, { withFileTypes: true })) {
+          if (!tool.isDirectory()) continue;
+          const subReadme = join(toolsDir, tool.name, 'README.md');
+          if (!existsSync(subReadme)) continue;
+
+          const subContent = readFileSync(subReadme, 'utf8');
+          if (subContent.includes('## License')) {
+            warn(`${repoName}/tools/${tool.name}/README.md ... has license section (should be removed)`);
+            totalIssues++;
+            if (FIX) {
+              const cleaned = removeReadmeLicenseSection(subContent);
+              writeFileSync(subReadme, cleaned);
+              ok(`${repoName}/tools/${tool.name}/README.md ... license section removed (--fix)`);
+              totalIssues--;
+            }
+          }
+        }
+      } catch {}
+    }
+  }
+
+  log('');
+  if (totalIssues === 0) {
+    log('  All README license sections are correct.\n');
+  } else {
+    log(`  ${totalIssues} issue(s) found. Run with --fix to auto-repair.\n`);
+  }
+
+  return totalIssues;
+}
+
 // Main
 if (command === 'init') {
   await init(target === 'init' ? '.' : target);
 } else if (command === 'check') {
   const repoPath = (target === 'check') ? '.' : target;
   const issues = await check(repoPath);
+  process.exit(issues > 0 ? 1 : 0);
+} else if (command === 'readme-license') {
+  const repoPath = (target === 'readme-license') ? '.' : target;
+  const issues = await readmeLicense(repoPath);
   process.exit(issues > 0 ? 1 : 0);
 } else if (command === '--help' || command === '-h' || command === 'help') {
   console.log(`
@@ -336,6 +452,8 @@ if (command === 'init') {
     init --from-standard       Apply WIP Computer defaults (MIT+AGPL, CLA, attribution).
     check [path]               Audit repo against saved config. Exit 1 if issues found.
     check --fix [path]         Auto-fix issues (update LICENSE files, wrong copyright).
+    readme-license [path]      Scan README license sections. Works on one repo or a directory of repos.
+    readme-license --fix       Apply standard license block to all READMEs. Remove from sub-tools.
     help                       Show this help.
 
   On first run, if no config exists, check will offer to run init.

--- a/tools/wip-license-guard/core.mjs
+++ b/tools/wip-license-guard/core.mjs
@@ -131,15 +131,59 @@ AGPLv3. AGPLv3 for personal use is free.${attribution ? '\n\n' + attribution : '
 
   return `## License
 
+Dual-license model designed to keep tools free while preventing commercial resellers.
+
 \`\`\`
 MIT      All CLI tools, MCP servers, skills, and hooks (use anywhere, no restrictions).
 AGPLv3   Commercial redistribution, marketplace listings, or bundling into paid services.
 \`\`\`
 
-Dual-license model designed to keep tools free while preventing commercial resellers.
-
 AGPLv3 for personal use is free. Commercial licenses available.
 
+### Can I use this?
+
+**Yes, freely:**
+- Use any tool locally or on your own servers
+- Modify the code for your own projects
+- Include in your internal CI/CD pipelines
+- Fork it and send us feedback via PRs (we'd love that)
+
+**Need a commercial license:**
+- Bundle into a product you sell
+- List on a marketplace (VS Code, JetBrains, etc.)
+- Offer as part of a hosted/SaaS platform
+- Redistribute commercially
+
 Using these tools to build your own software is fine. Reselling the tools themselves is what requires a commercial license.
+
+By submitting a PR, you agree to the [Contributor License Agreement](CLA.md).
 ${attribution ? '\n' + attribution : ''}`;
+}
+
+/**
+ * Replace ## License section in readme content.
+ * If no ## License exists, appends the block at the end.
+ * Returns the updated content.
+ */
+export function replaceReadmeLicenseSection(content, config) {
+  const block = generateReadmeBlock(config);
+
+  // Match from "## License" to the next ## heading or end of file
+  const licenseRegex = /## License[\s\S]*?(?=\n## [^#]|\n---\s*$|$)/;
+  if (licenseRegex.test(content)) {
+    return content.replace(licenseRegex, block.trimEnd());
+  }
+
+  // No license section found, append
+  return content.trimEnd() + '\n\n' + block;
+}
+
+/**
+ * Remove ## License section from content (for sub-tool READMEs).
+ * Returns the updated content.
+ */
+export function removeReadmeLicenseSection(content) {
+  // Match from "## License" to the next ## heading or end of file
+  const licenseRegex = /\n## License[\s\S]*?(?=\n## [^#]|$)/;
+  return content.replace(licenseRegex, '').trimEnd() + '\n';
 }

--- a/tools/wip-license-guard/package.json
+++ b/tools/wip-license-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-guard",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "License compliance for your own repos. Ensures correct copyright, dual-license blocks, and LICENSE files.",
   "type": "module",
   "bin": {

--- a/tools/wip-license-hook/package.json
+++ b/tools/wip-license-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-hook",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "License rug-pull detection and dependency license compliance for open source projects",
   "type": "module",
   "main": "dist/cli/index.js",

--- a/tools/wip-readme-format/package.json
+++ b/tools/wip-readme-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-readme-format",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Reformat any repo's README to follow the WIP Computer standard. Agent-first, human-readable.",
   "type": "module",
   "bin": {

--- a/tools/wip-release/package.json
+++ b/tools/wip-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-release",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "One-command release pipeline. Bumps version, updates changelog + SKILL.md, publishes to npm + GitHub.",
   "main": "core.mjs",

--- a/tools/wip-repo-permissions-hook/package.json
+++ b/tools/wip-repo-permissions-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-permissions-hook",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "Repo visibility guard. Blocks repos from going public without a -private counterpart.",
   "main": "core.mjs",

--- a/tools/wip-repos/package.json
+++ b/tools/wip-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repos",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "Repo manifest reconciler. Single source of truth for repo organization. Like prettier for folder structure.",
   "main": "core.mjs",

--- a/tools/wip-universal-installer/package.json
+++ b/tools/wip-universal-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/universal-installer",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "type": "module",
   "description": "The Universal Interface specification for agent-native software. Teaches your AI how to build repos with every interface: CLI, Module, MCP Server, OpenClaw Plugin, Skill, Claude Code Hook.",
   "main": "detect.mjs",


### PR DESCRIPTION
Synced from private repo (commit cea2129).