### PR TITLE
v1.9.15: Fix all 5 root causes of truncated release notes (#121). Add --dry-run to readme-license. Update SKILL.md docs for wip-release and wip-license-guard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 
 
 
+
+## 1.9.15 (2026-03-14)
+
+Fix all 5 root causes of truncated release notes (#121). Add --dry-run to readme-license. Update SKILL.md docs for wip-release and wip-license-guard.
+
 ## 1.9.14 (2026-03-14)
 
 Add readme-license command to wip-license-guard. Scans all repos, applies standard license block, removes from sub-tools. License Guard now Stable.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ As Andrej Karpathy [said](https://x.com/karpathy/status/2024583544157458452): *"
 
 **License Guard**
 - Enforce licensing on every commit. Copyright, dual-license, CLA. Checked automatically.
-- Ensures your own repos have correct copyright, license type, and LICENSE files. Interactive first-run setup. Toolbox-aware: checks every sub-tool. Auto-fix mode repairs issues. `readme-license` scans all your repos and applies a standard license block to every README in one command. Removes duplicate license sections from sub-tool READMEs.
+- Ensures your own repos have correct copyright, license type, and LICENSE files. Interactive first-run setup. Toolbox-aware: checks every sub-tool. Auto-fix mode repairs issues
+- `readme-license` scans all your repos and applies a standard license block to every README in one command. Removes duplicate license sections from sub-tool READMEs
 - **Interfaces:** CLI
 - *Stable*
 - [Read more about License Guard](tools/wip-license-guard/cli.mjs)

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, module, mcp, skill, hook, plugin]
 metadata:
   display-name: "WIP AI DevOps Toolbox"
-  version: "1.9.14"
+  version: "1.9.15".9.14"
   homepage: "https://github.com/wipcomputer/wip-ai-devops-toolbox"
   author: "Parker Todd Brooks"
   category: dev-tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ai-devops-toolbox",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "The complete AI DevOps toolkit for AI-assisted development teams.",
   "private": true,

--- a/tools/ai-dir-template/package.json
+++ b/tools/ai-dir-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-init",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Scaffold the standard ai/ directory structure in any repo",
   "type": "module",
   "bin": {

--- a/tools/deploy-public/package.json
+++ b/tools/deploy-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/deploy-public",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Private-to-public repo sync. Excludes ai/ folder, creates PR, merges, cleans up branches.",
   "bin": {
     "deploy-public": "./deploy-public.sh"

--- a/tools/post-merge-rename/package.json
+++ b/tools/post-merge-rename/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/post-merge-rename",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Post-merge branch renaming. Appends --merged-YYYY-MM-DD to preserve history.",
   "bin": {
     "post-merge-rename": "./post-merge-rename.sh"

--- a/tools/wip-file-guard/package.json
+++ b/tools/wip-file-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-file-guard",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "Hook that blocks destructive edits to protected identity files. For Claude Code CLI and OpenClaw.",
   "main": "guard.mjs",

--- a/tools/wip-license-guard/SKILL.md
+++ b/tools/wip-license-guard/SKILL.md
@@ -29,17 +29,37 @@ metadata:
 
 # wip-license-guard
 
-License compliance for your own repos. Scans source files for correct copyright headers, verifies dual-license blocks (MIT + AGPL), and checks LICENSE files.
+License compliance for your own repos. Ensures correct copyright, dual-license blocks, LICENSE files, and README license sections.
 
 ## When to Use This Skill
 
 - Before a release, to verify all files have correct license headers
 - After adding new source files to a repo
 - To enforce the MIT/AGPL dual-license pattern
+- To standardize README license sections across all your repos
 
 ## CLI
 
 ```bash
-wip-license-guard /path/to/repo          # scan and report
-wip-license-guard /path/to/repo --fix    # auto-fix missing headers
+wip-license-guard check [path]                  # audit repo against config
+wip-license-guard check --fix [path]             # auto-fix LICENSE, CLA, copyright issues
+wip-license-guard init [path]                    # interactive setup
+wip-license-guard init --from-standard           # apply WIP Computer defaults (no prompts)
+wip-license-guard readme-license [path]          # audit README license sections
+wip-license-guard readme-license --dry-run       # preview what would change
+wip-license-guard readme-license --fix           # apply standard block to all READMEs
+```
+
+### readme-license
+
+Scans all repos for README license sections. Three modes:
+
+- **No flags**: audit only. Reports non-standard, missing, and sub-tool READMEs that shouldn't have license sections.
+- **--dry-run**: preview. Shows what each README has now and what would change. No files touched.
+- **--fix**: apply. Replaces non-standard sections with the standard dual MIT/AGPLv3 block. Removes license sections from sub-tool READMEs.
+
+Works on a single repo or a directory of repos:
+```bash
+wip-license-guard readme-license /path/to/one-repo
+wip-license-guard readme-license /path/to/directory-of-repos
 ```

--- a/tools/wip-license-guard/cli.mjs
+++ b/tools/wip-license-guard/cli.mjs
@@ -13,6 +13,7 @@ const HELP_FLAGS = ['--help', '-h', 'help'];
 const command = HELP_FLAGS.some(f => args.includes(f)) ? 'help' : (args.find(a => !a.startsWith('--')) || 'check');
 const target = args.find((a, i) => i > 0 && !a.startsWith('--')) || '.';
 const FIX = args.includes('--fix');
+const DRY_RUN = args.includes('--dry-run');
 const QUIET = args.includes('--quiet');
 const FROM_STANDARD = args.includes('--from-standard');
 
@@ -321,7 +322,8 @@ async function check(repoPath) {
 }
 
 async function readmeLicense(targetPath) {
-  log(`\n  wip-license-guard readme-license${FIX ? ' --fix' : ''}\n`);
+  const mode = FIX ? '--fix' : DRY_RUN ? '--dry-run' : '';
+  log(`\n  wip-license-guard readme-license${mode ? ' ' + mode : ''}\n`);
 
   // Detect if targetPath is a single repo or a directory of repos
   const repos = [];
@@ -376,6 +378,14 @@ async function readmeLicense(targetPath) {
       } else if (content.includes('## License')) {
         warn(`${repoName}/README.md ... non-standard license section`);
         totalIssues++;
+        if (DRY_RUN) {
+          // Extract current license section for preview
+          const match = content.match(/## License[\s\S]*?(?=\n## [^#]|$)/);
+          if (match) {
+            log(`    current: ${match[0].split('\n').slice(0, 3).join(' | ').substring(0, 80)}...`);
+          }
+          log(`    would replace with: standard dual MIT/AGPLv3 block`);
+        }
         if (FIX) {
           const updated = replaceReadmeLicenseSection(content, config);
           writeFileSync(readmePath, updated);
@@ -385,6 +395,9 @@ async function readmeLicense(targetPath) {
       } else {
         warn(`${repoName}/README.md ... missing ## License`);
         totalIssues++;
+        if (DRY_RUN) {
+          log(`    would add: standard dual MIT/AGPLv3 block at end of README`);
+        }
         if (FIX) {
           const updated = replaceReadmeLicenseSection(content, config);
           writeFileSync(readmePath, updated);
@@ -410,6 +423,9 @@ async function readmeLicense(targetPath) {
           if (subContent.includes('## License')) {
             warn(`${repoName}/tools/${tool.name}/README.md ... has license section (should be removed)`);
             totalIssues++;
+            if (DRY_RUN) {
+              log(`    would remove: ## License section from sub-tool README`);
+            }
             if (FIX) {
               const cleaned = removeReadmeLicenseSection(subContent);
               writeFileSync(subReadme, cleaned);
@@ -425,8 +441,11 @@ async function readmeLicense(targetPath) {
   log('');
   if (totalIssues === 0) {
     log('  All README license sections are correct.\n');
+  } else if (DRY_RUN) {
+    log(`  ${totalIssues} issue(s) found. Dry run complete. No changes made.`);
+    log(`  Run with --fix to apply changes.\n`);
   } else {
-    log(`  ${totalIssues} issue(s) found. Run with --fix to auto-repair.\n`);
+    log(`  ${totalIssues} issue(s) found. Run with --dry-run to preview or --fix to apply.\n`);
   }
 
   return totalIssues;
@@ -453,6 +472,7 @@ if (command === 'init') {
     check [path]               Audit repo against saved config. Exit 1 if issues found.
     check --fix [path]         Auto-fix issues (update LICENSE files, wrong copyright).
     readme-license [path]      Scan README license sections. Works on one repo or a directory of repos.
+    readme-license --dry-run   Preview what would change. Shows current vs standard for each README.
     readme-license --fix       Apply standard license block to all READMEs. Remove from sub-tools.
     help                       Show this help.
 

--- a/tools/wip-license-guard/package.json
+++ b/tools/wip-license-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-guard",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "License compliance for your own repos. Ensures correct copyright, dual-license blocks, and LICENSE files.",
   "type": "module",
   "bin": {

--- a/tools/wip-license-hook/package.json
+++ b/tools/wip-license-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-license-hook",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "License rug-pull detection and dependency license compliance for open source projects",
   "type": "module",
   "main": "dist/cli/index.js",

--- a/tools/wip-readme-format/package.json
+++ b/tools/wip-readme-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-readme-format",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Reformat any repo's README to follow the WIP Computer standard. Agent-first, human-readable.",
   "type": "module",
   "bin": {

--- a/tools/wip-release/SKILL.md
+++ b/tools/wip-release/SKILL.md
@@ -78,9 +78,27 @@ wip-release checks that product docs (dev update, roadmap, readme-first) were up
 - **--skip-product-check**: bypasses the gate
 
 Checks:
-1. `ai/dev-updates/` has a file from the last 3 days
+1. `ai/dev-updates/` has a file modified since the last release tag
 2. `ai/product/plans-prds/roadmap.md` was modified since last release
 3. `ai/product/readme-first-product.md` was modified since last release
+
+### Skill Publish to Website
+
+After publishing, wip-release auto-copies SKILL.md to your website as plain text. Any AI can fetch the URL and get clean install instructions.
+
+**Setup:** Set the `WIP_WEBSITE_REPO` environment variable to your website repo path. That's it.
+
+**How it works:**
+1. If SKILL.md exists and `WIP_WEBSITE_REPO` is set, copies SKILL.md to `{website}/wip.computer/install/{name}.txt`
+2. Runs `deploy.sh` in the website repo to push live
+3. Non-blocking: if deploy fails, the release still succeeds
+
+**Name resolution (first match wins):**
+1. `.publish-skill.json` in repo root: `{ "name": "my-tool" }`
+2. `package.json` name (with `@scope/` prefix stripped)
+3. Directory name (with `-private` suffix stripped)
+
+No config file needed. Every repo with a SKILL.md auto-publishes on release.
 
 ### Module
 

--- a/tools/wip-release/cli.js
+++ b/tools/wip-release/cli.js
@@ -23,7 +23,8 @@ const skipStaleCheck = args.includes('--skip-stale-check');
 const skipWorktreeCheck = args.includes('--skip-worktree-check');
 const notesFilePath = flag('notes-file');
 let notes = flag('notes');
-let notesSource = notes ? 'flag' : 'none'; // track where notes came from
+// Bug fix #121: use strict check, not truthiness. --notes="" is empty, not absent.
+let notesSource = (notes !== null && notes !== undefined && notes !== '') ? 'flag' : 'none';
 
 // Release notes priority (highest wins):
 //   1. --notes-file=path          Explicit file path (always wins)

--- a/tools/wip-release/core.mjs
+++ b/tools/wip-release/core.mjs
@@ -90,19 +90,27 @@ export function syncSkillVersion(repoPath, newVersion) {
 export function updateChangelog(repoPath, newVersion, notes) {
   const changelogPath = join(repoPath, 'CHANGELOG.md');
   const date = new Date().toISOString().split('T')[0];
-  const entry = `## ${newVersion} (${date})\n\n${notes || 'Release.'}\n`;
+
+  // Bug fix #121: never silently default to "Release." when notes are empty.
+  // If notes are empty at this point, warn loudly.
+  if (!notes || !notes.trim()) {
+    console.warn(`  ! WARNING: No release notes provided for v${newVersion}. CHANGELOG entry will be minimal.`);
+    notes = 'No release notes provided.';
+  }
+
+  const entry = `## ${newVersion} (${date})\n\n${notes}\n`;
 
   if (!existsSync(changelogPath)) {
-    writeFileSync(changelogPath, `# Changelog\n\n${entry}\n`);
+    writeFileSync(changelogPath, `# Changelog\n\n${entry}`);
     return;
   }
 
   let content = readFileSync(changelogPath, 'utf8');
-  // Insert after the # Changelog header
-  const headerMatch = content.match(/^# Changelog\s*\n/);
+  // Insert after the # Changelog header (single newline, no accumulation)
+  const headerMatch = content.match(/^# Changelog\s*\n+/);
   if (headerMatch) {
     const insertPoint = headerMatch[0].length;
-    content = content.slice(0, insertPoint) + '\n' + entry + '\n' + content.slice(insertPoint);
+    content = content.slice(0, insertPoint) + entry + '\n' + content.slice(insertPoint);
   } else {
     content = `# Changelog\n\n${entry}\n${content}`;
   }
@@ -395,7 +403,7 @@ export function buildReleaseNotes(repoPath, currentVersion, newVersion, notes) {
   }
 
   // Install section
-  lines.push('### Install\n');
+  lines.push('### Install');
   lines.push('```bash');
   lines.push(`npm install -g ${pkg.name}@${newVersion}`);
   lines.push('```');
@@ -438,6 +446,18 @@ export function createGitHubRelease(repoPath, newVersion, notes, currentVersion)
       '--notes-file', '.release-notes-tmp.md',
       '--repo', repoSlug
     ], { cwd: repoPath, stdio: 'inherit' });
+
+    // Bug fix #121: verify the release was actually created
+    try {
+      const verify = execFileSync('gh', [
+        'release', 'view', `v${newVersion}`,
+        '--repo', repoSlug, '--json', 'body', '--jq', '.body | length'
+      ], { cwd: repoPath, encoding: 'utf8' }).trim();
+      const bodyLen = parseInt(verify, 10);
+      if (bodyLen < 50) {
+        console.warn(`  ! GitHub release body is only ${bodyLen} chars. Notes may be truncated.`);
+      }
+    } catch {}
   } finally {
     try { execFileSync('rm', ['-f', tmpFile]); } catch {}
   }

--- a/tools/wip-release/package.json
+++ b/tools/wip-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-release",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "One-command release pipeline. Bumps version, updates changelog + SKILL.md, publishes to npm + GitHub.",
   "main": "core.mjs",

--- a/tools/wip-repo-permissions-hook/package.json
+++ b/tools/wip-repo-permissions-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repo-permissions-hook",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "Repo visibility guard. Blocks repos from going public without a -private counterpart.",
   "main": "core.mjs",

--- a/tools/wip-repos/package.json
+++ b/tools/wip-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-repos",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "Repo manifest reconciler. Single source of truth for repo organization. Like prettier for folder structure.",
   "main": "core.mjs",

--- a/tools/wip-universal-installer/package.json
+++ b/tools/wip-universal-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/universal-installer",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "The Universal Interface specification for agent-native software. Teaches your AI how to build repos with every interface: CLI, Module, MCP Server, OpenClaw Plugin, Skill, Claude Code Hook.",
   "main": "detect.mjs",


### PR DESCRIPTION
Synced from private repo (commit 6cd6ca8).